### PR TITLE
feat(workflow): add SPIEGEL football n8n workflow (core-only)

### DIFF
--- a/docs/PR-PLAN.md
+++ b/docs/PR-PLAN.md
@@ -1,0 +1,46 @@
+# PR-Plan (mehrere Pull Requests)
+
+## PR 1 – Scaffold & CI
+**Branch:** `feat/scaffold-and-ci`  
+**Inhalt:** `.gitignore`, `LICENSE`, `README.md` (grundlegend), `.env.example`, CI (`.github/workflows/ci.yml`), PR/Issue-Templates.  
+**Message:** `chore: scaffold repo and add CI`
+
+## PR 2 – Workflow Base
+**Branch:** `feat/workflow-base`  
+**Inhalt:** `workflows/spiegel-fussball-fa.json` (Cron, RSS, Filter Männer, Bildextraktion, Text-Fallback Struktur ohne API Keys).  
+**Message:** `feat(workflow): add spiegel fussball base with filters`
+
+## PR 3 – OpenAI Translation
+**Branch:** `feat/openai-translation`  
+**Inhalt:** HTTP-Request Node, Prompt-Set, Mapping `title_fa`, `docs/translation.md`.  
+**Message:** `feat(translation): integrate OpenAI DE→FA with prompt`
+
+## PR 4 – Telegram Output
+**Branch:** `feat/telegram-output`  
+**Inhalt:** sendPhoto/sendMessage Nodes, `scripts/test_telegram.sh`.  
+**Message:** `feat(telegram): send photo+caption with link and text fallback`
+
+## PR 5 – Runbook & Compliance
+**Branch:** `docs/runbook-and-compliance`  
+**Inhalt:** `docs/runbook.md`, `docs/compliance.md` und README-Update.  
+**Message:** `docs: add runbook and compliance guidelines`
+
+---
+
+## Git-Befehle (Beispiel)
+```bash
+git init
+git remote add origin <YOUR_REPO_URL>
+git checkout -b feat/scaffold-and-ci
+git add .
+git commit -m "chore: scaffold repo and add CI"
+git push -u origin feat/scaffold-and-ci
+# Ersten PR erstellen…
+
+# Nächster PR auf neuer Branch
+git checkout -b feat/workflow-base
+# (Nur relevante Änderungen committen)
+git commit -m "feat(workflow): add spiegel fussball base with filters"
+git push -u origin feat/workflow-base
+# PR erstellen…
+```

--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -1,0 +1,8 @@
+# Compliance & Content-Richtlinien
+
+- **Quelle:** Offizielle **RSS-Feeds** der SPIEGEL-Rubrik *Sport/Fußball* nutzen.
+- **Umfang:** Nur **Titel/Teaser + Link** veröffentlichen. **Keine Volltexte**.
+- **Kennzeichnung:** Immer „Quelle: SPIEGEL“ + Original-Link.
+- **Bilder:** Nur verwenden, wenn im Feed als `enclosure` / `media:content` vorhanden.
+- **Filter:** Nur Männer-Fußball; offensichtliche Frauen-Artikel ausschließen.
+- **Caching/State:** Kein persistenter Speicher; zeitfensterbasierte Duplikatsvermeidung.

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1,0 +1,23 @@
+# Runbook (Betrieb & Troubleshooting)
+
+## Secrets
+- **OPENAI_API_KEY**: Rotation alle 90 Tage empfohlen.
+- **TELEGRAM_BOT_TOKEN**: Bei Verdacht auf Leak neu generieren (BotFather).
+- **TELEGRAM_CHAT_ID**: Konstante Kanal-ID (z. B. `-100…`).
+
+## Health
+- Workflow in n8n **aktiv**? Cron läuft?
+- **Telegram-Bot Admin** im Kanal?
+- Outbound erreichbar: `api.openai.com`, `api.telegram.org`.
+
+## Fehler
+- **429/5xx OpenAI**: automatisches Retry per Node-Optionen (oder manuell erneut triggern).
+- **Telegram 400 (Bad Request)**: Prüfe `chat_id`, Bild-URL, Nachrichtengröße.
+- **Keine Bilder**: Fallback sendMessage (Text) greift automatisch.
+
+## Änderung
+- Anpassungen am Prompt in `PreparePrompt`-Node.
+- Filterliste (Frauen/Women) im Node „Filter: nur Männer-Fußball“.
+
+## Monitoring (leicht)
+- Optional separaten **Error-Workflow** mit *Error Trigger* erstellen und an Telegram-Admin senden.

--- a/docs/translation.md
+++ b/docs/translation.md
@@ -1,0 +1,23 @@
+# Übersetzung (DE → FA) – Style & Prompt
+
+**Stil:** locker, prägnant.  
+**Eigennamen:** transliterieren (z. B. Bayern München → بایرن مونیخ).  
+**Output:** nur der übersetzte **Titel**, keine Erklärungen/Emojis/Hashtags.
+
+## Prompt (System & User)
+System:
+> Du bist ein Übersetzer DE→FA. Stil locker. Übersetze nur den Titel prägnant ins Persische. Eigennamen transliterieren (z.B. Bayern München→بایرن مونیخ). Keine Erklärungen, nur den übersetzten Titel.
+
+User:
+> ${title}
+
+**Temperatur:** 0.2  
+**Modell (ENV):** `OPENAI_MODEL` (Standard: `gpt-4o-mini`).
+
+## API
+Endpoint: `POST https://api.openai.com/v1/chat/completions`  
+Header: `Authorization: Bearer ${OPENAI_API_KEY}` & `Content-Type: application/json`
+
+## Beispiele
+- *„Bayern siegt spät in Leipzig“* → **«پیروزی دیرهنگام بایرن در لایپزیگ»**
+- *„Kane trifft doppelt – BVB patzt“* → **«کین دبل می‌زند؛ دورتموند لغزش می‌کند»**

--- a/scripts/test_telegram.sh
+++ b/scripts/test_telegram.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -f .env ]]; then
+  export $(grep -v '^#' .env | xargs) || true
+fi
+
+: "${TELEGRAM_BOT_TOKEN:?Set TELEGRAM_BOT_TOKEN}"
+: "${TELEGRAM_CHAT_ID:?Set TELEGRAM_CHAT_ID}"
+
+TEXT="n8n Spiegel Fußball → FA: Testnachricht ✅"
+curl -sS -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage"   -d "chat_id=${TELEGRAM_CHAT_ID}"   --data-urlencode "text=${TEXT}"   -d "disable_web_page_preview=true"   -d "parse_mode=HTML"
+
+echo "✔ Testnachricht gesendet."

--- a/workflows/spiegel-fussball-fa.json
+++ b/workflows/spiegel-fussball-fa.json
@@ -14,8 +14,27 @@
           ]
         }
       }
+    },
+    {
+      "id": "RSS",
+      "name": "RSS Read (SPIEGEL Fußball)",
+      "type": "n8n-nodes-base.rssFeedRead",
+      "typeVersion": 1,
+      "position": [520, 200],
+      "parameters": {
+        "url": "https://www.spiegel.de/sport/fussball/index.rss",
+        "options": { "splitLines": false }
+      }
     }
   ],
-  "connections": {},
+  "connections": {
+    "Cron (every 15 min)": {
+      "main": [
+        [
+          { "node": "RSS Read (SPIEGEL Fußball)", "type": "main", "index": 0 }
+        ]
+      ]
+    }
+  },
   "settings": { "timezone": "Europe/Berlin" }
 }

--- a/workflows/spiegel-fussball-fa.json
+++ b/workflows/spiegel-fussball-fa.json
@@ -13,22 +13,22 @@
           ]
         }
       },
-      "id": "ed85de68-c65b-42e1-9678-cb9a8665a844",
+      "id": "56d663a0-4401-49cd-a6f8-af639b5d5ac9",
       "name": "Cron (every 15 min)",
       "type": "n8n-nodes-base.cron",
       "typeVersion": 1,
-      "position": [-832, -320]
+      "position": [704, -336]
     },
     {
       "parameters": {
         "url": "https://www.spiegel.de/sport/fussball/index.rss",
         "options": {}
       },
-      "id": "287f7708-0d85-460e-bdb8-5d39e910cb9f",
+      "id": "a9d39561-a8ea-437b-8d12-70673852852c",
       "name": "RSS Read (SPIEGEL Fußball)",
       "type": "n8n-nodes-base.rssFeedRead",
       "typeVersion": 1,
-      "position": [-544, -320]
+      "position": [992, -336]
     },
     {
       "parameters": {
@@ -43,81 +43,49 @@
               "id": "c1-title-not-frauen",
               "leftValue": "={{ $json.title || '' }}",
               "rightValue": "frauen",
-              "operator": {
-                "type": "string",
-                "operation": "notContains",
-                "name": "filter.operator.notContains"
-              }
+              "operator": { "type": "string", "operation": "notContains", "name": "filter.operator.notContains" }
             },
             {
               "id": "c2-title-not-women",
               "leftValue": "={{ $json.title || '' }}",
               "rightValue": "women",
-              "operator": {
-                "type": "string",
-                "operation": "notContains",
-                "name": "filter.operator.notContains"
-              }
+              "operator": { "type": "string", "operation": "notContains", "name": "filter.operator.notContains" }
             },
             {
               "id": "c3-title-not-frauen-buli",
               "leftValue": "={{ $json.title || '' }}",
               "rightValue": "frauen-bundesliga",
-              "operator": {
-                "type": "string",
-                "operation": "notContains",
-                "name": "filter.operator.notContains"
-              }
+              "operator": { "type": "string", "operation": "notContains", "name": "filter.operator.notContains" }
             },
             {
               "id": "c4-title-not-frauenwm",
               "leftValue": "={{ $json.title || '' }}",
               "rightValue": "frauenwm",
-              "operator": {
-                "type": "string",
-                "operation": "notContains",
-                "name": "filter.operator.notContains"
-              }
+              "operator": { "type": "string", "operation": "notContains", "name": "filter.operator.notContains" }
             },
             {
               "id": "c5-sum-not-frauen",
               "leftValue": "={{ $json.summary || $json.description || '' }}",
               "rightValue": "frauen",
-              "operator": {
-                "type": "string",
-                "operation": "notContains",
-                "name": "filter.operator.notContains"
-              }
+              "operator": { "type": "string", "operation": "notContains", "name": "filter.operator.notContains" }
             },
             {
               "id": "c6-sum-not-women",
               "leftValue": "={{ $json.summary || $json.description || '' }}",
               "rightValue": "women",
-              "operator": {
-                "type": "string",
-                "operation": "notContains",
-                "name": "filter.operator.notContains"
-              }
+              "operator": { "type": "string", "operation": "notContains", "name": "filter.operator.notContains" }
             },
             {
               "id": "c7-sum-not-frauen-buli",
               "leftValue": "={{ $json.summary || $json.description || '' }}",
               "rightValue": "frauen-bundesliga",
-              "operator": {
-                "type": "string",
-                "operation": "notContains",
-                "name": "filter.operator.notContains"
-              }
+              "operator": { "type": "string", "operation": "notContains", "name": "filter.operator.notContains" }
             },
             {
               "id": "c8-sum-not-frauenwm",
               "leftValue": "={{ $json.summary || $json.description || '' }}",
               "rightValue": "frauenwm",
-              "operator": {
-                "type": "string",
-                "operation": "notContains",
-                "name": "filter.operator.notContains"
-              }
+              "operator": { "type": "string", "operation": "notContains", "name": "filter.operator.notContains" }
             }
           ],
           "combinator": "and"
@@ -126,19 +94,29 @@
       },
       "type": "n8n-nodes-base.filter",
       "typeVersion": 2.2,
-      "position": [-304, -320],
-      "id": "cded9c96-221d-4128-a888-19d09725fe5e",
+      "position": [1232, -336],
+      "id": "62eda0b0-d9d9-4ac9-8b62-233e6807762e",
       "name": "Filter (men-only)"
     },
     {
       "parameters": {
-        "functionCode": "return items.map(i => {\n  const j = i.json;\n  let image = null;\n  // RSS variants\n  if (j.enclosure && j.enclosure.url) image = j.enclosure.url;\n  if (!image && j[\"media:content\"] && j[\"media:content\"].url) image = j[\"media:content\"].url;\n  if (!image && typeof j.content === 'string') {\n    const m = j.content.match(/<img[^>]+src=[\"']([^\"']+)[\"']/i);\n    if (m) image = m[1];\n  }\n  // Normalize teaser (strip HTML)\n  const rawTeaser = (j.summary || j.description || '');\n  const teaser = typeof rawTeaser === 'string' ? rawTeaser.replace(/<[^>]*>/g,'').trim() : '';\n  i.json.imageUrl = image || null;\n  i.json.teaser = teaser;\n  return i;\n});"
+        "jsCode": "// Extract image & teaser\nreturn items.map(item => {\n  const j = item.json;\n  let image = null;\n  if (j.enclosure && j.enclosure.url) image = j.enclosure.url;\n  if (!image && j[\"media:content\"] && j[\"media:content\"].url) image = j[\"media:content\"].url;\n  if (!image && typeof j.content === 'string') {\n    const m = j.content.match(/<img[^>]+src=[\"']([^\"']+)[\"']/i);\n    if (m) image = m[1];\n  }\n  const rawTeaser = (j.summary || j.description || '');\n  const teaser = typeof rawTeaser === 'string' ? rawTeaser.replace(/<[^>]*>/g, '').trim() : '';\n  item.json.imageUrl = image || null;\n  item.json.teaser = teaser;\n  return item;\n});"
       },
-      "id": "f7a22f4d-6c3f-4b6a-9d46-3d2f5c7e8c11",
-      "name": "Extract image & teaser",
-      "type": "n8n-nodes-base.function",
+      "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [-64, -320]
+      "position": [1456, -336],
+      "id": "5ffee35f-f226-4455-bff8-dafc61065aca",
+      "name": "Code"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Time window: last 20 minutes (stateless)\nconst cutoff = new Date(Date.now() - 20 * 60 * 1000);\nreturn items.filter(item => {\n  const j = item.json;\n  const d = new Date(j.isoDate || j.pubDate || j.date || j.pubdate || 0);\n  return d > cutoff;\n});"
+      },
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1680, -336],
+      "id": "2fc7d14d-7a3b-46e5-a9bd-2c3bf8e2a7fb",
+      "name": "Time window (last 20 min)"
     }
   ],
   "pinData": {},
@@ -146,41 +124,34 @@
     "Cron (every 15 min)": {
       "main": [
         [
-          {
-            "node": "RSS Read (SPIEGEL Fußball)",
-            "type": "main",
-            "index": 0
-          }
+          { "node": "RSS Read (SPIEGEL Fußball)", "type": "main", "index": 0 }
         ]
       ]
     },
     "RSS Read (SPIEGEL Fußball)": {
       "main": [
         [
-          {
-            "node": "Filter (men-only)",
-            "type": "main",
-            "index": 0
-          }
+          { "node": "Filter (men-only)", "type": "main", "index": 0 }
         ]
       ]
     },
     "Filter (men-only)": {
       "main": [
         [
-          {
-            "node": "Extract image & teaser",
-            "type": "main",
-            "index": 0
-          }
+          { "node": "Code", "type": "main", "index": 0 }
+        ]
+      ]
+    },
+    "Code": {
+      "main": [
+        [
+          { "node": "Time window (last 20 min)", "type": "main", "index": 0 }
         ]
       ]
     }
   },
   "active": false,
-  "settings": {
-    "executionOrder": "v1"
-  },
+  "settings": { "executionOrder": "v1" },
   "versionId": "293ac0e2-b494-4989-99f0-da073ee4e975",
   "meta": {
     "templateCredsSetupCompleted": true,

--- a/workflows/spiegel-fussball-fa.json
+++ b/workflows/spiegel-fussball-fa.json
@@ -129,6 +129,16 @@
       "position": [-304, -320],
       "id": "cded9c96-221d-4128-a888-19d09725fe5e",
       "name": "Filter (men-only)"
+    },
+    {
+      "parameters": {
+        "functionCode": "return items.map(i => {\n  const j = i.json;\n  let image = null;\n  // RSS variants\n  if (j.enclosure && j.enclosure.url) image = j.enclosure.url;\n  if (!image && j[\"media:content\"] && j[\"media:content\"].url) image = j[\"media:content\"].url;\n  if (!image && typeof j.content === 'string') {\n    const m = j.content.match(/<img[^>]+src=[\"']([^\"']+)[\"']/i);\n    if (m) image = m[1];\n  }\n  // Normalize teaser (strip HTML)\n  const rawTeaser = (j.summary || j.description || '');\n  const teaser = typeof rawTeaser === 'string' ? rawTeaser.replace(/<[^>]*>/g,'').trim() : '';\n  i.json.imageUrl = image || null;\n  i.json.teaser = teaser;\n  return i;\n});"
+      },
+      "id": "f7a22f4d-6c3f-4b6a-9d46-3d2f5c7e8c11",
+      "name": "Extract image & teaser",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 2,
+      "position": [-64, -320]
     }
   ],
   "pinData": {},
@@ -149,6 +159,17 @@
         [
           {
             "node": "Filter (men-only)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Filter (men-only)": {
+      "main": [
+        [
+          {
+            "node": "Extract image & teaser",
             "type": "main",
             "index": 0
           }

--- a/workflows/spiegel-fussball-fa.json
+++ b/workflows/spiegel-fussball-fa.json
@@ -1,40 +1,170 @@
 {
-  "name": "SPIEGEL Football Base",
+  "name": "FootballSpiegel",
   "nodes": [
     {
-      "id": "Cron",
-      "name": "Cron (every 15 min)",
-      "type": "n8n-nodes-base.cron",
-      "typeVersion": 1,
-      "position": [240, 200],
       "parameters": {
         "triggerTimes": {
           "item": [
-            { "mode": "everyX", "unit": "minutes", "value": 15 }
+            {
+              "mode": "everyX",
+              "value": 15,
+              "unit": "minutes"
+            }
           ]
         }
-      }
+      },
+      "id": "ed85de68-c65b-42e1-9678-cb9a8665a844",
+      "name": "Cron (every 15 min)",
+      "type": "n8n-nodes-base.cron",
+      "typeVersion": 1,
+      "position": [-832, -320]
     },
     {
-      "id": "RSS",
+      "parameters": {
+        "url": "https://www.spiegel.de/sport/fussball/index.rss",
+        "options": {}
+      },
+      "id": "287f7708-0d85-460e-bdb8-5d39e910cb9f",
       "name": "RSS Read (SPIEGEL Fußball)",
       "type": "n8n-nodes-base.rssFeedRead",
       "typeVersion": 1,
-      "position": [520, 200],
+      "position": [-544, -320]
+    },
+    {
       "parameters": {
-        "url": "https://www.spiegel.de/sport/fussball/index.rss",
-        "options": { "splitLines": false }
-      }
+        "conditions": {
+          "options": {
+            "caseSensitive": false,
+            "typeValidation": "strict",
+            "version": 2
+          },
+          "conditions": [
+            {
+              "id": "c1-title-not-frauen",
+              "leftValue": "={{ $json.title || '' }}",
+              "rightValue": "frauen",
+              "operator": {
+                "type": "string",
+                "operation": "notContains",
+                "name": "filter.operator.notContains"
+              }
+            },
+            {
+              "id": "c2-title-not-women",
+              "leftValue": "={{ $json.title || '' }}",
+              "rightValue": "women",
+              "operator": {
+                "type": "string",
+                "operation": "notContains",
+                "name": "filter.operator.notContains"
+              }
+            },
+            {
+              "id": "c3-title-not-frauen-buli",
+              "leftValue": "={{ $json.title || '' }}",
+              "rightValue": "frauen-bundesliga",
+              "operator": {
+                "type": "string",
+                "operation": "notContains",
+                "name": "filter.operator.notContains"
+              }
+            },
+            {
+              "id": "c4-title-not-frauenwm",
+              "leftValue": "={{ $json.title || '' }}",
+              "rightValue": "frauenwm",
+              "operator": {
+                "type": "string",
+                "operation": "notContains",
+                "name": "filter.operator.notContains"
+              }
+            },
+            {
+              "id": "c5-sum-not-frauen",
+              "leftValue": "={{ $json.summary || $json.description || '' }}",
+              "rightValue": "frauen",
+              "operator": {
+                "type": "string",
+                "operation": "notContains",
+                "name": "filter.operator.notContains"
+              }
+            },
+            {
+              "id": "c6-sum-not-women",
+              "leftValue": "={{ $json.summary || $json.description || '' }}",
+              "rightValue": "women",
+              "operator": {
+                "type": "string",
+                "operation": "notContains",
+                "name": "filter.operator.notContains"
+              }
+            },
+            {
+              "id": "c7-sum-not-frauen-buli",
+              "leftValue": "={{ $json.summary || $json.description || '' }}",
+              "rightValue": "frauen-bundesliga",
+              "operator": {
+                "type": "string",
+                "operation": "notContains",
+                "name": "filter.operator.notContains"
+              }
+            },
+            {
+              "id": "c8-sum-not-frauenwm",
+              "leftValue": "={{ $json.summary || $json.description || '' }}",
+              "rightValue": "frauenwm",
+              "operator": {
+                "type": "string",
+                "operation": "notContains",
+                "name": "filter.operator.notContains"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "type": "n8n-nodes-base.filter",
+      "typeVersion": 2.2,
+      "position": [-304, -320],
+      "id": "cded9c96-221d-4128-a888-19d09725fe5e",
+      "name": "Filter (men-only)"
     }
   ],
+  "pinData": {},
   "connections": {
     "Cron (every 15 min)": {
       "main": [
         [
-          { "node": "RSS Read (SPIEGEL Fußball)", "type": "main", "index": 0 }
+          {
+            "node": "RSS Read (SPIEGEL Fußball)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "RSS Read (SPIEGEL Fußball)": {
+      "main": [
+        [
+          {
+            "node": "Filter (men-only)",
+            "type": "main",
+            "index": 0
+          }
         ]
       ]
     }
   },
-  "settings": { "timezone": "Europe/Berlin" }
+  "active": false,
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "versionId": "293ac0e2-b494-4989-99f0-da073ee4e975",
+  "meta": {
+    "templateCredsSetupCompleted": true,
+    "instanceId": "74338d6634b4803f2c29b4ddb0f0645d98af0974959d1701b31f3894967620b7"
+  },
+  "id": "m8Hae79VZG5Ut0rd",
+  "tags": []
 }

--- a/workflows/spiegel-fussball-fa.json
+++ b/workflows/spiegel-fussball-fa.json
@@ -1,0 +1,21 @@
+{
+  "name": "SPIEGEL Football Base",
+  "nodes": [
+    {
+      "id": "Cron",
+      "name": "Cron (every 15 min)",
+      "type": "n8n-nodes-base.cron",
+      "typeVersion": 1,
+      "position": [240, 200],
+      "parameters": {
+        "triggerTimes": {
+          "item": [
+            { "mode": "everyX", "unit": "minutes", "value": 15 }
+          ]
+        }
+      }
+    }
+  ],
+  "connections": {},
+  "settings": { "timezone": "Europe/Berlin" }
+}


### PR DESCRIPTION
This PR introduces the base n8n workflow for fetching SPIEGEL football news.

### Workflow steps implemented
1. **Cron (every 15 minutes)**  
   Triggers the workflow regularly.

2. **RSS Read (SPIEGEL Fußball)**  
   Fetches the official SPIEGEL football RSS feed.

3. **Filter (men-only)**  
   Excludes articles related to women's football (Frauen, women, Frauen-Bundesliga, Frauen-WM).

4. **Code: Extract image & teaser**  
   - Extracts image URL from RSS `enclosure`, `media:content`, or `<img>` tags.  
   - Normalizes teaser text by stripping HTML.

5. **Code: Time window (last 20 minutes, stateless)**  
   Passes only new items published in the last 20 minutes.  
   Prevents duplicates without storing state.

### Notes
- Only core nodes (Cron, RSS, Filter, Code) are used for compatibility.  
- Workflow is not active yet — safe to import and extend.  
- Next PRs will add:
  - PR 3: Translation via OpenAI
  - PR 4: Posting to Telegram channel
