### PR TITLE
feat: Add Telegram output with image/text routing for SPIEGEL Fußball (FA)

### DIFF
--- a/workflows/spiegel-fussball-fa.json
+++ b/workflows/spiegel-fussball-fa.json
@@ -19,7 +19,7 @@
       "typeVersion": 1,
       "position": [
         432,
-        -240
+        -576
       ]
     },
     {
@@ -33,7 +33,7 @@
       "typeVersion": 1,
       "position": [
         656,
-        -240
+        -576
       ]
     },
     {
@@ -135,7 +135,7 @@
       "typeVersion": 2.2,
       "position": [
         880,
-        -240
+        -576
       ],
       "id": "35407f8c-6022-463d-b0a2-1a1d4d395757",
       "name": "Filter (men-only)"
@@ -158,7 +158,7 @@
       "typeVersion": 2,
       "position": [
         1328,
-        -240
+        -576
       ]
     },
     {
@@ -173,8 +173,8 @@
           "conditions": [
             {
               "id": "e18ac0f4-85be-4e6f-a17a-ccbc1efa4403",
-              "leftValue": "",
-              "rightValue": "",
+              "leftValue": "={{ $json.provider }}",
+              "rightValue": "openai",
               "operator": {
                 "type": "string",
                 "operation": "equals",
@@ -192,7 +192,7 @@
       "typeVersion": 2,
       "position": [
         1552,
-        -240
+        -576
       ]
     },
     {
@@ -203,7 +203,7 @@
       "typeVersion": 2,
       "position": [
         1776,
-        -336
+        -592
       ],
       "id": "5ae2c560-e13e-4527-9aa4-96f44c64ff11",
       "name": "Build OpenAI body"
@@ -236,7 +236,7 @@
       "typeVersion": 4,
       "position": [
         2000,
-        -336
+        -504
       ],
       "id": "375ababe-15d7-4d6d-98b4-933cdf726c3e",
       "name": "OpenAI Translate (HTTP)",
@@ -258,8 +258,8 @@
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [
-        2224,
-        -336
+        2448,
+        -576
       ],
       "id": "6aea3ecd-443f-4bc4-9f0e-665ca0508cf5",
       "name": "Pick title_fa (OpenAI)"
@@ -271,8 +271,8 @@
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [
-        1776,
-        -144
+        432,
+        -256
       ],
       "id": "7343f566-6e97-4c32-b13d-afee6d70e4ac",
       "name": "Build Gemini body"
@@ -303,8 +303,8 @@
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4,
       "position": [
-        2000,
-        -144
+        656,
+        -256
       ],
       "id": "f7f42b82-d724-4b36-b38b-6202aad561c8",
       "name": "Gemini Translate (HTTP)"
@@ -316,37 +316,63 @@
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [
-        2224,
-        -144
+        880,
+        -256
       ],
       "id": "8a4b2202-8308-4f01-a3c3-1700489e0b3c",
       "name": "Pick title_fa (Gemini)"
     },
     {
       "parameters": {
-        "jsCode": "// Filter items: keep only those newer than 20 minutes\nconst cutoff = Date.now() - 20 * 60 * 60 * 1000;\n\n// In Code-Node v2 benutzen wir $input.all() um alle Items zu holen\nconst inputItems = $input.all();\nconst out = [];\n\nfor (const item of inputItems) {\n  const j = item.json;\n\n  // Mögliche Datumsfelder aus dem RSS\n  const candidates = [j.isoDate, j.pubDate, j.date, j.pubdate];\n\n  let pubDate = null;\n  for (const c of candidates) {\n    if (!c) continue;\n    const d = new Date(c);\n    if (!isNaN(d.getTime())) {\n      pubDate = d;\n      break;\n    }\n  }\n\n  // Falls kein Datum gefunden → (für Tests) durchlassen\n  if (!pubDate) {\n    out.push(item);\n    continue;\n  }\n\n  if (pubDate.getTime() > cutoff) {\n    out.push(item); // neu genug → behalten\n  }\n}\n\n// Array von Items zurückgeben\nreturn out;\n"
+        "jsCode": "// Filter items: keep only those newer than 20 minutes\nconst cutoff = Date.now() - 20  * 60 * 1000; // 20 Minuten * 60 * 1000;\n\n// In Code-Node v2 benutzen wir $input.all() um alle Items zu holen\nconst inputItems = $input.all();\nconst out = [];\n\nfor (const item of inputItems) {\n  const j = item.json;\n\n  // Mögliche Datumsfelder aus dem RSS\n  const candidates = [j.isoDate, j.pubDate, j.date, j.pubdate];\n\n  let pubDate = null;\n  for (const c of candidates) {\n    if (!c) continue;\n    const d = new Date(c);\n    if (!isNaN(d.getTime())) {\n      pubDate = d;\n      break;\n    }\n  }\n\n  // Falls kein Datum gefunden → (für Tests) durchlassen\n  if (!pubDate) {\n    out.push(item);\n    continue;\n  }\n\n  if (pubDate.getTime() > cutoff) {\n    out.push(item); // neu genug → behalten\n  }\n}\n\n// Array von Items zurückgeben\nreturn out;\n"
       },
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [
-        2448,
-        -336
+        2672,
+        -576
       ],
       "id": "881a606e-4ea0-4f05-827a-369f6cbdb44b",
       "name": "Time window (last 20 min)"
     },
     {
       "parameters": {
-        "jsCode": "// Build Telegram caption: FA title + source + link (max ~1000 chars)\nreturn items.map(item => {\n  const j = item.json;\n\n  const titleFa = (j.title_fa || j.title || '').toString().trim();\n  const link = (j.link || j.guid || '').toString().trim();\n\n  // Caption: nur Überschrift + Quelle + Link (gemäß Vorgabe)\n  let caption = titleFa;\n  if (link) caption += `\\n\\nمنبع: SPIEGEL\\n${link}`;\n\n  // Telegram: Caption-Limit ~1024 (safe cut)\n  if (caption.length > 1000) {\n    // wenn Link existiert, Platz für Link freilassen\n    if (link && !caption.endsWith(link)) {\n      const roomForLink = 1 + link.length; // \"\\n\" + link\n      caption = caption.slice(0, Math.max(0, 1000 - roomForLink - 1)) + '…\\n' + link;\n    } else {\n      caption = caption.slice(0, 1000);\n    }\n  }\n\n  j.caption = caption;\n  return item;\n});\n"
+        "jsCode": "// Build Telegram caption: FA title + source + link (max ~1000 chars)\nconst inputItems = $input.all();\n\nreturn inputItems.map(item => {\n  const j = item.json;\n\n  const titleFa = (j.title_fa || j.title || '').toString().trim();\n  const link = (j.link || j.guid || '').toString().trim();\n\n  let caption = titleFa;\n  if (link) caption += `\\n\\nمنبع: SPIEGEL\\n${link}`;\n\n  if (caption.length > 1000) {\n    if (link && !caption.endsWith(link)) {\n      const roomForLink = 1 + link.length; // \"\\n\" + link\n      caption = caption.slice(0, Math.max(0, 1000 - roomForLink - 1)) + '…\\n' + link;\n    } else {\n      caption = caption.slice(0, 1000);\n    }\n  }\n\n  j.caption = caption;\n  return item;\n});\n"
       },
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [
-        2672,
-        -336
+        2896,
+        -576
       ],
       "id": "5992093d-5b39-4107-9c92-541e5cb65853",
       "name": "Build caption"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Code Node v2 – Run once for all items\nconst inputItems = $input.all();\n\nreturn inputItems.map(item => {\n  const j = item.json;\n  let image = null;\n\n  // 1) Standard-RSS-Felder\n  if (j.enclosure?.url) image = j.enclosure.url;\n  if (!image && j['media:content']?.url) image = j['media:content'].url;\n\n  // 2) Alternative Media-Felder\n  if (!image && j['media:thumbnail']?.url) image = j['media:thumbnail'].url;\n  if (!image && j['media:group']?.['media:content']?.url) image = j['media:group']['media:content'].url;\n\n  // 3) Notlösung: <img src=\"...\"> aus HTML extrahieren\n  const html = (j.content || j.summary || j.description || '');\n  if (!image && typeof html === 'string') {\n    const m = html.match(/<img[^>]+src=[\"']([^\"']+)[\"']/i);\n    if (m) image = m[1];\n  }\n\n  // Teaser ohne HTML\n  const rawTeaser = (j.summary || j.description || '');\n  const teaser = typeof rawTeaser === 'string'\n    ? rawTeaser.replace(/<[^>]*>/g, '').trim()\n    : '';\n\n  item.json.imageUrl = image || '';\n  item.json.teaser = teaser;\n\n  return item;\n});\n"
+      },
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        1104,
+        -576
+      ],
+      "id": "0734a457-9592-47b5-8a8f-87c199860656",
+      "name": "Extract imageUrl & teaser"
+    },
+    {
+      "parameters": {
+        "jsCode": "const items = $input.all();\n\nconst esc = (s='') => s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');\nconst isValidPhoto = (u='') => /^https?:\\/\\//i.test(u) && /(jpg|jpeg|png|gif)/i.test(u);\n\nconst hostFrom = (link='') => {\n  const m = link.match(/^https?:\\/\\/([^\\/?#]+)/i);\n  return m ? m[1].replace(/^www\\./,'') : '';\n};\n\nreturn items.map(i => {\n  const j = i.json || {};\n  const titleFa = (j.title_fa || j.title || '').toString().trim();\n  const link = (j.link || '').toString().trim();\n  let imageUrl = (j.imageUrl || '').toString().trim();\n  if (!isValidPhoto(imageUrl)) imageUrl = '';\n\nlet caption = `📰 <b>${esc(titleFa)}</b>`;\nif (link) {\n  const host = hostFrom(link);\n  // Link in die Caption einbetten (HTML)\n  caption += `\\n🔗 <a href=\"${esc(link)}\">${esc(host || 'لینک خبر')}</a>`;\n}\n\n  // Kanalname immer unten anhängen\ncaption += `\\n\\n@FootbllSpiegelFa`;\n  \n// Länge begrenzen\nif (caption.length > 1024) caption = caption.slice(0, 1010) + '…';\n\n\n  const text = `${caption}${link ? `\\n\\n<a href=\"${esc(link)}\">لینک خبر</a>` : ''}`;\n  const replyMarkup = link ? { inline_keyboard: [[{ text: 'لینک خبر 🔗', url: link }]] } : undefined;\n\n  return {\n    json: {\n      ...j,\n      telegram: { photo: imageUrl, caption, text, replyMarkup }\n    }\n  };\n});\n"
+      },
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        3120,
+        -576
+      ],
+      "id": "8b1e2a96-795f-4f7d-a7f0-c5b8f2680ead",
+      "name": "Build Telegram payload"
     },
     {
       "parameters": {
@@ -359,53 +385,106 @@
           },
           "conditions": [
             {
-              "id": "9ccce2fc-4fd6-4b2b-b39a-2fc96fc09d75",
-              "leftValue": "=={{ $json.imageUrl || '' }}",
+              "id": "93f7ff28-0178-4465-a77a-9a74a7ce52b3",
+              "leftValue": "={{ $json.telegram.photo || '' }}",
               "rightValue": "",
               "operator": {
                 "type": "string",
                 "operation": "notEmpty",
                 "singleValue": true
               }
-            },
-            {
-              "id": "4194c4a8-c062-4a70-8a68-32f6b7e5c0b0",
-              "leftValue": "",
-              "rightValue": "",
-              "operator": {
-                "type": "string",
-                "operation": "equals",
-                "name": "filter.operator.equals"
-              }
             }
           ],
           "combinator": "and"
         },
-        "options": {
-          "ignoreCase": false
-        }
+        "options": {}
       },
-      "type": "n8n-nodes-base.filter",
+      "type": "n8n-nodes-base.if",
       "typeVersion": 2.2,
       "position": [
-        2896,
-        -336
+        3344,
+        -576
       ],
-      "id": "eab4f7d8-23b3-4bb1-a452-5d95954a2bab",
+      "id": "6ffe8923-58fd-496d-bdaa-11bee40697ce",
       "name": "IF has image"
     },
     {
       "parameters": {
-        "jsCode": "// Code Node v2 – Run once for all items\nconst inputItems = $input.all();\n\nreturn inputItems.map(item => {\n  const j = item.json;\n  let image = null;\n\n  // 1) Standard-RSS-Felder\n  if (j.enclosure?.url) image = j.enclosure.url;\n  if (!image && j['media:content']?.url) image = j['media:content'].url;\n\n  // 2) Alternative Media-Felder\n  if (!image && j['media:thumbnail']?.url) image = j['media:thumbnail'].url;\n  if (!image && j['media:group']?.['media:content']?.url) image = j['media:group']['media:content'].url;\n\n  // 3) Notlösung: <img src=\"...\"> aus HTML extrahieren\n  const html = (j.content || j.summary || j.description || '');\n  if (!image && typeof html === 'string') {\n    const m = html.match(/<img[^>]+src=[\"']([^\"']+)[\"']/i);\n    if (m) image = m[1];\n  }\n\n  // Teaser ohne HTML\n  const rawTeaser = (j.summary || j.description || '');\n  const teaser = typeof rawTeaser === 'string'\n    ? rawTeaser.replace(/<[^>]*>/g, '').trim()\n    : '';\n\n  item.json.imageUrl = image || '';\n  item.json.teaser = teaser;\n\n  return item;\n});\n"
+        "chatId": "-1002971367902",
+        "text": "={{ $json.telegram.text }}",
+        "additionalFields": {
+          "parse_mode": "HTML"
+        }
+      },
+      "type": "n8n-nodes-base.telegram",
+      "typeVersion": 1.2,
+      "position": [
+        3568,
+        -480
+      ],
+      "id": "3659fc1f-7a48-45b0-bb09-308158762d95",
+      "name": "Send a text message",
+      "webhookId": "b5a0b437-6ee2-441e-8c30-26cf65270faf",
+      "credentials": {
+        "telegramApi": {
+          "id": "yaYLqfC3EW8JxhwD",
+          "name": "Telegram account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "operation": "sendPhoto",
+        "chatId": "-1002971367902",
+        "file": "={{ $json.telegram.photo }}",
+        "additionalFields": {
+          "caption": "={{ $json.telegram.caption }}\n",
+          "parse_mode": "HTML"
+        }
+      },
+      "type": "n8n-nodes-base.telegram",
+      "typeVersion": 1.2,
+      "position": [
+        3568,
+        -672
+      ],
+      "id": "894afe56-770c-4653-b790-7ee74e25e1cd",
+      "name": "Send a photo message",
+      "webhookId": "67ac8ce5-7c23-43e0-a976-e7681e06a86d",
+      "credentials": {
+        "telegramApi": {
+          "id": "yaYLqfC3EW8JxhwD",
+          "name": "Telegram account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "return $input.all().map(i => ({ json: { title: i.json.title, imageUrl: i.json.imageUrl }}));\n"
       },
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [
-        1104,
-        -240
+        432,
+        -896
       ],
-      "id": "0734a457-9592-47b5-8a8f-87c199860656",
-      "name": "Extract imageUrl & teaser"
+      "id": "04ca9758-ffd2-43b3-8b99-0961aa88ce82",
+      "name": "Code"
+    },
+    {
+      "parameters": {
+        "mode": "combine",
+        "combineBy": "combineByPosition",
+        "options": {}
+      },
+      "type": "n8n-nodes-base.merge",
+      "typeVersion": 3.2,
+      "position": [
+        2224,
+        -576
+      ],
+      "id": "b1c1a1c0-a967-40d6-aedb-1c769a8cba6c",
+      "name": "Merge"
     }
   ],
   "pinData": {},
@@ -463,13 +542,7 @@
             "index": 0
           }
         ],
-        [
-          {
-            "node": "Build Gemini body",
-            "type": "main",
-            "index": 0
-          }
-        ]
+        []
       ]
     },
     "Build OpenAI body": {
@@ -477,6 +550,11 @@
         [
           {
             "node": "OpenAI Translate (HTTP)",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Merge",
             "type": "main",
             "index": 0
           }
@@ -487,9 +565,9 @@
       "main": [
         [
           {
-            "node": "Pick title_fa (OpenAI)",
+            "node": "Merge",
             "type": "main",
-            "index": 0
+            "index": 1
           }
         ]
       ]
@@ -547,7 +625,7 @@
       "main": [
         [
           {
-            "node": "IF has image",
+            "node": "Build Telegram payload",
             "type": "main",
             "index": 0
           }
@@ -564,13 +642,63 @@
           }
         ]
       ]
+    },
+    "Build Telegram payload": {
+      "main": [
+        [
+          {
+            "node": "IF has image",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "IF has image": {
+      "main": [
+        [
+          {
+            "node": "Send a photo message",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Send a text message",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Send a text message": {
+      "main": [
+        []
+      ]
+    },
+    "Code": {
+      "main": [
+        []
+      ]
+    },
+    "Merge": {
+      "main": [
+        [
+          {
+            "node": "Pick title_fa (OpenAI)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
     }
   },
   "active": false,
   "settings": {
     "executionOrder": "v1"
   },
-  "versionId": "a18bfdb2-9527-4039-ad48-61da628ec4f3",
+  "versionId": "68db4391-2066-45d2-bf8b-0d3e0e294ec8",
   "meta": {
     "templateCredsSetupCompleted": true,
     "instanceId": "74338d6634b4803f2c29b4ddb0f0645d98af0974959d1701b31f3894967620b7"


### PR DESCRIPTION
🎯 Ziel

Dieser PR erweitert den n8n-Workflow für SPIEGEL Fußball → Telegram (FA), sodass Nachrichten mit/ohne Bild zuverlässig ins Telegram-Channel @FootbllSpiegelFa gepostet werden.

✨ Änderungen

Filter (men-only): Nur Männer-Fußball-News werden durchgelassen.

Translation: Titel via OpenAI (GPT-4o-mini) ins Persische (title_fa).

Time Window: Nur Artikel der letzten 20 Minuten werden berücksichtigt.

Image Handling:

Extraktion von imageUrl aus RSS (enclosure, media, <img>-Tag).

Fix: imageUrl wird durch Merge-Node nach OpenAI-Request weitergereicht.

Caption-Building:

FA-Titel + Hostname + Original-Link.

Kanalname @FootbllSpiegelFa immer am Ende der Caption.

Telegram Output:

IF has image → Routing:

✅ mit Bild → sendPhoto

❌ ohne Bild → sendMessage

✅ Ergebnis

Telegram-Posts enthalten jetzt Titel (FA), korrekten News-Link, optional Bild, und immer den Kanalnamen.

Nachrichten ohne Bild werden sauber als Text-Posts gesendet.

🔜 Nächste Schritte (separat)

- Optional: Gemini-Support einbauen (parallel zu OpenAI).

- Feinschliff bei Captions (z.B. Teaser-Text ergänzen).